### PR TITLE
[STLND-2079] action for ECR release

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
   # ORIGINAL
   #on:
-  workflow_dispatch:
+#  workflow_dispatch:
 #    inputs:
 #      previous_version:
 #        type: string

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ COPY .citools/swagger .citools/swagger
 
 # Include vendored dependencies
 COPY pkg/util/xorm pkg/util/xorm
-COPY pkg/apis/folder pkg/apis/folder
+#COPY pkg/apis/folder pkg/apis/folder
 COPY pkg/apis/secret pkg/apis/secret
 COPY pkg/apiserver pkg/apiserver
 COPY pkg/apimachinery pkg/apimachinery


### PR DESCRIPTION
https://stella-systems.atlassian.net/browse/STLND-2079

Small PR to fix build and have command `make build-docker-full` work.

Initially this PR also contained the GH action to execute build and push docker to Stella ECR, but forks does not have access to secrets from organization ad it was failing:
https://github.com/stella-systems/grafana/actions/runs/15975568197
So I have extracted to separate repository and manual trigger for release:
https://github.com/stella-systems/grafana-build/blob/develop/.github/workflows/stella-release-ecr.yml